### PR TITLE
getRouteCollection() bypass the use of cache

### DIFF
--- a/src/Flint/Provider/RoutingServiceProvider.php
+++ b/src/Flint/Provider/RoutingServiceProvider.php
@@ -70,9 +70,6 @@ class RoutingServiceProvider implements \Silex\ServiceProviderInterface
             return new Router($app['routing.loader'], $app['routing.resource'], $options, $app['request_context'], $app['logger']);
         });
 
-        $app['routes'] = function (Application $app) {
-            return $app['router']->getRouteCollection();
-        };
 
         $app['url_matcher'] = $app->raw('router');
         $app['url_generator'] = $app->raw('router');


### PR DESCRIPTION
Maybe I'm mistaken, but it seems to me that calling directly getRouteCollection() completely bypass the pre-existing cache. getRouteCollection() is only supposed to be called by getMatcher or getGenerator who wrap a cache around it.

What do you think?
